### PR TITLE
chore(image): use `snaefellsjokull` tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging:
 
 services:
   l2_execution_engine:
-    image: gcr.io/evmchain/taiko-geth:taiko
+    image: gcr.io/evmchain/taiko-geth:snaefellsjokull
     restart: unless-stopped
     pull_policy: always
     stop_grace_period: 3m
@@ -55,7 +55,7 @@ services:
     <<: *logging
 
   taiko_client_driver:
-    image: gcr.io/evmchain/taiko-client:main
+    image: gcr.io/evmchain/taiko-client:snaefellsjokull
     restart: unless-stopped
     pull_policy: always
     depends_on:
@@ -82,7 +82,7 @@ services:
     <<: *logging
 
   taiko_client_proposer:
-    image: gcr.io/evmchain/taiko-client:main
+    image: gcr.io/evmchain/taiko-client:snaefellsjokull
     restart: unless-stopped
     pull_policy: always
     depends_on:


### PR DESCRIPTION
Use `snaefellsjokull` tags for `taiko-geth` and `taiko-client` images, which will be maintained separately from the `latest` / `main` tags.