### PR TITLE
 Make Hard-coded prover's port dynamic

### DIFF
--- a/script/start-prover-relayer.sh
+++ b/script/start-prover-relayer.sh
@@ -8,7 +8,7 @@ if [ "$ENABLE_PROVER" == "true" ]; then
         chmod +x ./wait
     fi
 
-    WAIT_HOSTS=zkevm-chain-prover-rpcd:9000 WAIT_TIMEOUT=180 ./wait
+    WAIT_HOSTS=zkevm-chain-prover-rpcd:${PORT_ZKEVM_CHAIN_PROVER_RPCD} WAIT_TIMEOUT=180 ./wait
 
     taiko-client prover \
         --l1.ws ${L1_ENDPOINT_WS} \


### PR DESCRIPTION
The `zkevm-chain-prover-rpcd port` should respect environment variables like the rest of the script