### PR TITLE
fix(env): fix sample env file formatting

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,7 +20,8 @@ TAIKO_L2_ADDRESS=0x0000777700000000000000000000000000000001
 
 # A L2 account private key for building throw-away L2 blocks, for more detailed information, please
 # see whitepaper's `5.5.1 Invalid Blocks`.
-L2_THROWAWAY_BLOCK_BUILDER_PRIVATE_KEY=92954368afd3caa1f3ce3ead0069c1af414054aefe1ef9aeacc1bf426222ce38 # LibAnchorSignature.K_GOLDEN_TOUCH_PRIVATEKEY
+# LibAnchorSignature.K_GOLDEN_TOUCH_PRIVATEKEY
+L2_THROWAWAY_BLOCK_BUILDER_PRIVATE_KEY=92954368afd3caa1f3ce3ead0069c1af414054aefe1ef9aeacc1bf426222ce38
 
 ############################### REQUIRED #####################################
 # L1 Sepolia RPC endpoints (you will need an RPC provider such as Alchemy or Infura--or, run a full Sepolia node yourself)


### PR DESCRIPTION
On the line defining L2_THROWAWAY_BLOCK_BUILDER_PRIVATE_KEY there was a space at the end, then a comment. This was causing the following error:

"invalid throwaway blocks builder private key: invalid hex character ' ' in private key"