### PR TITLE
fix (script): use docker internal port

### DIFF
--- a/script/start-prover-relayer.sh
+++ b/script/start-prover-relayer.sh
@@ -12,9 +12,9 @@ if [ "$ENABLE_PROVER" == "true" ]; then
 
     taiko-client prover \
         --l1.ws ${L1_ENDPOINT_WS} \
-        --l2.ws ws://l2_execution_engine:${PORT_L2_EXECTION_ENGINE_WS} \
+        --l2.ws ws://l2_execution_engine:8546 \
         --l1.http ${L1_ENDPOINT_HTTP} \
-        --l2.http http://l2_execution_engine:${PORT_L2_EXECTION_ENGINE_HTTP} \
+        --l2.http http://l2_execution_engine:8545 \
         --taikoL1 ${TAIKO_L1_ADDRESS} \
         --taikoL2 ${TAIKO_L2_ADDRESS} \
         --zkevmRpcdEndpoint http://zkevm-chain-prover-rpcd:${PORT_ZKEVM_CHAIN_PROVER_RPCD} \


### PR DESCRIPTION
The original script was using public ports instead of internal docker ports. However, the `l2_execution_engine` relies on the internal docker IP of `simple-taiko-node-l2_execution_engine`, so it should be using internal docker ports as well. 

Originally, if you change the default ports `PORT_L2_EXECTION_ENGINE_HTTP` and `PORT_L2_EXECTION_ENGINE_WS` in `.env` file, the prover relayer could not connect to the execution engine as it connects to the ports in `.env` file. However, it should connect to 8545 and 8546 to work properly. 