### PR TITLE
feat: handle graceful shutdown

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
     image: gcr.io/evmchain/taiko-client:grimsvotn
     restart: unless-stopped
     pull_policy: always
+    stop_grace_period: 3m
     depends_on:
       - l2_execution_engine
     env_file:
@@ -77,6 +78,7 @@ services:
     image: gcr.io/evmchain/taiko-client:grimsvotn
     restart: unless-stopped
     pull_policy: always
+    stop_grace_period: 30s
     depends_on:
       - l2_execution_engine
       - taiko_client_driver

--- a/script/start-driver.sh
+++ b/script/start-driver.sh
@@ -3,7 +3,7 @@
 set -eou pipefail
 
 if [ "$DISABLE_P2P_SYNC" == "false" ]; then
-    taiko-client driver \
+    exec taiko-client driver \
         --l1.ws ${L1_ENDPOINT_WS} \
         --l2.ws ws://l2_execution_engine:8546 \
         --l2.auth http://l2_execution_engine:8551 \
@@ -14,7 +14,7 @@ if [ "$DISABLE_P2P_SYNC" == "false" ]; then
         --p2p.checkPointSyncUrl https://rpc.test.taiko.xyz \
         --p2p.syncTimeout "5000"
 else
-    taiko-client driver \
+    exec taiko-client driver \
         --l1.ws ${L1_ENDPOINT_WS} \
         --l2.ws ws://l2_execution_engine:8546 \
         --l2.auth http://l2_execution_engine:8551 \

--- a/script/start-proposer.sh
+++ b/script/start-proposer.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
 set -eou pipefail
+trap "kill $!; exit 0" INT TERM
 
 if [ "$ENABLE_PROPOSER" == "true" ]; then
-    taiko-client proposer \
+    exec taiko-client proposer \
       --l1.ws ${L1_ENDPOINT_WS} \
       --l2.http http://l2_execution_engine:8545 \
       --taikoL1 ${TAIKO_L1_ADDRESS} \
@@ -12,5 +13,6 @@ if [ "$ENABLE_PROPOSER" == "true" ]; then
       --l2.suggestedFeeRecipient ${L2_SUGGESTED_FEE_RECIPIENT} \
       --minimalBlockGasLimit "5000000"
 else
-    sleep infinity
+    sleep infinity &
+    wait $!
 fi

--- a/script/start-prover-relayer.sh
+++ b/script/start-prover-relayer.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -eou pipefail
+trap "kill $!; exit 0" INT TERM
 
 if [ "$ENABLE_PROVER" == "true" ]; then
     if [ ! -f "./wait" ];then
@@ -8,9 +9,10 @@ if [ "$ENABLE_PROVER" == "true" ]; then
         chmod +x ./wait
     fi
 
-    WAIT_HOSTS=zkevm-chain-prover-rpcd:${PORT_ZKEVM_CHAIN_PROVER_RPCD} WAIT_TIMEOUT=180 ./wait
+    WAIT_HOSTS=zkevm-chain-prover-rpcd:${PORT_ZKEVM_CHAIN_PROVER_RPCD} WAIT_TIMEOUT=180 ./wait &
+    wait $!
 
-    taiko-client prover \
+    exec taiko-client prover \
         --l1.ws ${L1_ENDPOINT_WS} \
         --l2.ws ws://l2_execution_engine:8546 \
         --l1.http ${L1_ENDPOINT_HTTP} \
@@ -22,5 +24,6 @@ if [ "$ENABLE_PROVER" == "true" ]; then
         --l1.proverPrivKey ${L1_PROVER_PRIVATE_KEY} \
         --maxConcurrentProvingJobs 1
 else
-    sleep infinity
+    sleep infinity &
+    wait $!
 fi

--- a/script/start-zkevm-chain-rpcd.sh
+++ b/script/start-zkevm-chain-rpcd.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -eou pipefail
+trap "kill $!; exit 0" INT TERM
 
 if [ "$ENABLE_PROVER" == "true" ]; then
     mkdir -p /data
@@ -9,7 +10,8 @@ if [ "$ENABLE_PROVER" == "true" ]; then
         wget https://storage.googleapis.com/zkevm-circuits-keys/19.bin -P /data
     fi
 
-    /prover_rpcd --bind 0.0.0.0:${PORT_ZKEVM_CHAIN_PROVER_RPCD}
+    exec /prover_rpcd --bind 0.0.0.0:${PORT_ZKEVM_CHAIN_PROVER_RPCD}
 else
-    sleep infinity
+    sleep infinity &
+    wait $!
 fi


### PR DESCRIPTION
It's better to call `exec` so that the running application can handle interrupts.
I added a shell trap which exits if the script is sleeping
Added more generous grace period to taiko driver and prover relayer

resolves #61