### PR TITLE
Use variable assignment for relayer port

### DIFF
--- a/script/l3/start-prover-relayer.sh
+++ b/script/l3/start-prover-relayer.sh
@@ -8,7 +8,7 @@ if [ "$ENABLE_PROVER" == "true" ]; then
         chmod +x ./wait
     fi
 
-    WAIT_HOSTS=l3_zkevm_chain_prover_rpcd:9000 WAIT_TIMEOUT=3600 ./wait
+    WAIT_HOSTS=l3_zkevm_chain_prover_rpcd:${PORT_ZKEVM_CHAIN_PROVER_RPCD} WAIT_TIMEOUT=3600 ./wait
 
     if [ "$ENABLE_PROVER" == "true" ]; then
         taiko-client prover \
@@ -19,7 +19,7 @@ if [ "$ENABLE_PROVER" == "true" ]; then
         --taikoL1 ${TAIKO_L1_ADDRESS} \
         --taikoL2 ${TAIKO_L2_ADDRESS} \
         --taikoProverPoolL1 ${PROVER_POOL_ADDRESS} \
-        --zkevmRpcdEndpoint http://l3_zkevm_chain_prover_rpcd:9000 \
+        --zkevmRpcdEndpoint http://l3_zkevm_chain_prover_rpcd:${PORT_ZKEVM_CHAIN_PROVER_RPCD} \
         --zkevmRpcdParamsPath /data \
         --l1.proverPrivKey ${L2_PROVER_PRIVATE_KEY} \
         --maxConcurrentProvingJobs 1 \
@@ -33,7 +33,7 @@ if [ "$ENABLE_PROVER" == "true" ]; then
         --taikoL1 ${TAIKO_L1_ADDRESS} \
         --taikoL2 ${TAIKO_L2_ADDRESS} \
         --taikoProverPoolL1 ${PROVER_POOL_ADDRESS} \
-        --zkevmRpcdEndpoint http://l3_zkevm_chain_prover_rpcd:9000 \
+        --zkevmRpcdEndpoint http://l3_zkevm_chain_prover_rpcd:${PORT_ZKEVM_CHAIN_PROVER_RPCD} \
         --zkevmRpcdParamsPath /data \
         --l1.proverPrivKey ${L2_PROVER_PRIVATE_KEY} \
         --maxConcurrentProvingJobs 1 \


### PR DESCRIPTION
The value ${PORT_ZKEVM_CHAIN_PROVER_RPCD} set in .env.l3 should be used for the host.