### PR TITLE
fix(eldfell): Use env variable for port assignment in zkevm rpcd script

### DIFF
--- a/script/l3/start-zkevm-chain-rpcd.sh
+++ b/script/l3/start-zkevm-chain-rpcd.sh
@@ -7,7 +7,7 @@ if [ "$ENABLE_PROVER" == "true" ]; then
 
     rm -rf /data/kzg_bn254_21.srs && wget https://storage.googleapis.com/zkevm-circuits-keys/kzg_bn254_21.srs -P /data
 
-    /prover_rpcd --bind 0.0.0.0:9000
+    /prover_rpcd --bind 0.0.0.0:${PORT_ZKEVM_CHAIN_PROVER_RPCD}
 else
     sleep infinity
 fi


### PR DESCRIPTION
Using :9000 works only if the .env.l3 variable is set to 9000.