### PR TITLE
docs: update comments on .env.sample.l3

### DIFF
--- a/.env.sample.l3
+++ b/.env.sample.l3
@@ -32,7 +32,7 @@ L2_ENDPOINT_WS=
 # `ENABLE_PROVER` to true and set `L2_PROVER_PRIVATE_KEY`.
 ENABLE_PROVER=false
 PROVE_UNASSIGNED_BLOCKS=true
-# A L1 account (with balance) private key which will send the TaikoL1.proveBlock transactions.
+# A L2 account (with balance) private key which will send the TaikoL1.proveBlock transactions.
 L2_PROVER_PRIVATE_KEY=
 
 # If you want to be a proposer who proposes L3 execution engine's transactions in mempool to Taiko L1 protocol (on L2)


### PR DESCRIPTION
I think L2 account is required for L3 prover.