### PR TITLE
fix(eldfell): Use correct env flag in start-prover-relayer.sh

### DIFF
--- a/script/l3/start-prover-relayer.sh
+++ b/script/l3/start-prover-relayer.sh
@@ -10,7 +10,7 @@ if [ "$ENABLE_PROVER" == "true" ]; then
 
     WAIT_HOSTS=l3_zkevm_chain_prover_rpcd:${PORT_ZKEVM_CHAIN_PROVER_RPCD} WAIT_TIMEOUT=3600 ./wait
 
-    if [ "$ENABLE_PROVER" == "true" ]; then
+    if [ "$PROVE_UNASSIGNED_BLOCKS" == "true" ]; then
         taiko-client prover \
         --l1.ws ${L2_ENDPOINT_WS} \
         --l2.ws ws://l3_execution_engine:8546 \


### PR DESCRIPTION
ENABLE_PROVER was being used for the if/else statement instead of PROVE_UNASSIGNED_BLOCKS, meaning all simple nodes are attempting to prove unassigned blocks without this change.