### PR TITLE
Add Comment for .env.sample.l3

### DIFF
--- a/.env.sample.l3
+++ b/.env.sample.l3
@@ -23,7 +23,7 @@ DISABLE_P2P_SYNC=false
 
 ############################### REQUIRED #####################################
 # L2 RPC endpoints (you will need to run a fully synced L2 node to start a L3 node)
-# If you are using a local Taiko L2 node, you can refer to it as "host.docker.internal" or use the local IP address
+# If you are using a local Taiko L2 node, you can refer to it as "host.docker.internal:8546", "host.docker.internal:8547" port is different from the .env since it is accessing internally.
 L2_ENDPOINT_HTTP=
 L2_ENDPOINT_WS=
 


### PR DESCRIPTION
In .env.samle , the port number is 8547 and 8548, but for internal reference, 8545 and 8546 is OK (8547 and 8548 for external reference)