### PR TITLE
feat(env): Use erigon as default L1 node

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,9 @@
 CHAIN_ID=167005
 
 # Exposed ports
+PORT_L1_EXECTION_ENGINE_HTTP=8447
+PORT_L1_EXECTION_ENGINE_METRICS=5960
+PORT_L1_EXECTION_ENGINE_P2P=30206
 PORT_L2_EXECTION_ENGINE_HTTP=8547
 PORT_L2_EXECTION_ENGINE_WS=8548
 PORT_L2_EXECTION_ENGINE_METRICS=6060
@@ -21,10 +24,14 @@ TAIKO_L2_ADDRESS=0x1000777700000000000000000000000000000001
 DISABLE_P2P_SYNC=false
 
 ############################### REQUIRED #####################################
+# Run archived Sepolia node yourself with erigon
+START_L1_NODE=true
+
 # L1 Sepolia RPC endpoints (you will need an RPC provider such as Infura or Alchemy, or run a full Sepolia node yourself)
 # If you are using a local Sepolia archive node, you can refer to it as "host.docker.internal" or use the local IP address
-L1_ENDPOINT_HTTP=
-L1_ENDPOINT_WS=
+# If you are using a remote Sepolia archive node, you can refer to it as "sepolia-erigon". with erigon, you can use same port for RPC and websocket
+L1_ENDPOINT_HTTP=http://sepolia_execution_engine:8545
+L1_ENDPOINT_WS=ws://sepolia_execution_engine:8545
 
 ############################### OPTIONAL #####################################
 # If you want to be a prover who generates and submits zero knowledge proofs of proposed L2 blocks, you need to change

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,26 @@ services:
       - "*"
     <<: *logging
 
+  sepolia_execution_engine:
+    image: thorax/erigon:v2.48.1
+    restart: unless-stopped
+    pull_policy: always
+    env_file:
+      - .env
+    volumes:
+      - sepolia_execution_engine_data:/data/sepolia
+      - ./script/l1:/script
+    ports:
+      - "${PORT_L1_EXECTION_ENGINE_METRICS}:6060"
+      - "${PORT_L1_EXECTION_ENGINE_HTTP}:8545"
+      - "${PORT_L1_EXECTION_ENGINE_P2P}:30303"
+      - "${PORT_L1_EXECTION_ENGINE_P2P}:30303/udp"
+    entrypoint:
+      - /bin/sh
+      - -c
+      - "/script/start-sepolia-node.sh"
+    <<: *logging
+
   taiko_client_driver:
     image: gcr.io/evmchain/taiko-client:grimsvotn
     restart: unless-stopped

--- a/script/l1/start-sepolia-node.sh
+++ b/script/l1/start-sepolia-node.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -eou pipefail
+
+if [ "$START_L1_NODE" == "true" ]; then
+    erigon \
+        --datadir=/data/sepolia \
+        --chain=sepolia \
+        --http=true \
+        --http.api=eth,web3,net,debug,txpool \
+        --http.addr=0.0.0.0 \
+        --http.vhosts=* \
+        --http.corsdomain=* \
+        --ws \
+        --internalcl \
+        --txpool.pricebump=0 \
+        --maxpeers=100
+else
+    sleep infinity
+fi


### PR DESCRIPTION
Our biggest pain point is the dependency of Sepolia L1 node to sync L2 node.
With this update, we can easily host Sepolia L1 node with erigon.

Currently, erigon's requirement is not high than prover(200GB storage). I hope this will make it easier to host L2 nodes.