### PR TITLE
feat: add update-env.sh util script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 .env.l3
+.env*.bak

--- a/script/util/update-env.sh
+++ b/script/util/update-env.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Behavior:
+# If a key is present in .env but not in .env.sample, it should be removed from .env.
+# If a key is present in .env.sample but not in .env, it should be added to .env.
+# If a key is present in both, and the value in .env.sample is non-empty, the value in .env should be updated.
+# If a key is present in both, and the value in .env.sample is empty, the value in .env should be retained.
+#
+# Run the script with "l2" or "l3" argument to update .env or .env.l3 file respectively.
+
+set -o pipefail  # Exit on pipe command errors
+
+# Function to update .env file with .env.sample
+update_env() {
+    local env_path=$1
+    local env_sample_path=$2
+
+    cp $env_path "${env_path}.bak"  # backup original .env file
+
+    # Process lines in .env.sample
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        if [[ $line =~ ^#.*$ || $line == "" ]]; then  # if comment or empty line
+            echo "$line" >> "${env_path}.new"
+        else
+            key=$(echo "$line" | cut -d '=' -f 1)  # extract the key
+            value_sample=$(echo "$line" | cut -d '=' -f 2-)  # extract the value from sample
+
+            # search for the key in .env file
+            value_env=$(grep "^$key=" "${env_path}.bak" | cut -d '=' -f 2-)
+            if [[ $value_env && -n $value_sample ]]; then
+                echo "$key=$value_sample" >> "${env_path}.new"  # use updated value from .env.sample
+            elif [[ $value_env ]]; then
+                echo "$key=$value_env" >> "${env_path}.new"  # use value from .env if key exists and sample value is empty
+            else
+                echo "$line" >> "${env_path}.new"  # use default value from .env.sample
+            fi
+        fi
+    done < "$env_sample_path"
+
+    mv "${env_path}.new" "$env_path"  # replace original .env file with the new one
+}
+
+# Command handling
+if [[ $1 == "l2" ]]; then
+    update_env ".env" ".env.sample"
+elif [[ $1 == "l3" ]]; then
+    update_env ".env.l3" ".env.sample.l3"
+else
+    echo "Invalid command. Use 'l2' or 'l3'."
+    exit 1
+fi
+


### PR DESCRIPTION
## description
util command to update .env file from sample. updates any default values we set, but retains user defined values. a default value is one defined in the sample, a user defined value is one that is blank in the sample. makes sure to update all comments and stuff.

## aside/idea
v1 of this feature to improve quality of life. in the future i think we could perhaps distribute a binary (from rust) for a command called "stn" (simple-taiko-node), which we can have the user install from a github release, via a curl command. we'd have the rust code here, compile and release the target binaries on github action, and have the user install it over curl like `curl github.com/releases/blah | bash`. see: https://raw.githubusercontent.com/foundry-rs/foundry/master/foundryup/install.

then we can alias those docker compose commands that users commonly use behind stl, like "stl up", "stl logs client", "stl logs exec", "stl update", etc.

however, we might just go with a GUI it seems too, so just an aside/idea.