### PR TITLE
fix(prover): Update .env.sample.l3 change PROVE_UNASSIGNED_BLOCKS default value

### DIFF
--- a/.env.sample.l3
+++ b/.env.sample.l3
@@ -31,7 +31,7 @@ L2_ENDPOINT_WS=
 # If you want to be a prover who generates and submits zero knowledge proofs of proposed L3 blocks, you need to change
 # `ENABLE_PROVER` to true and set `L2_PROVER_PRIVATE_KEY`.
 ENABLE_PROVER=false
-PROVE_UNASSIGNED_BLOCKS=true
+PROVE_UNASSIGNED_BLOCKS=false
 # How many provers you want to run concurrently, note that each prover will cost ~16 cores / ~32 GB memory.
 ZKEVM_CHAIN_INSTANCES_NUM=1
 # A L2 account (with balance) private key which will send the TaikoL1.proveBlock transactions.


### PR DESCRIPTION
change default PROVE_UNASSIGNED_BLOCKS true to false. 
If set to true, it will try to process unproved blocks in order, so completion will not be done unless the machine is strong. 
Set to false to change the default setting to process the block to which you are assigned.