### PR TITLE
fix(grimsvotn): fix `start-prover-relayer.sh` script

### DIFF
--- a/script/l2/start-prover-relayer.sh
+++ b/script/l2/start-prover-relayer.sh
@@ -21,7 +21,7 @@ if [ "$ENABLE_PROVER" == "true" ]; then
         --l1.proverPrivKey ${L1_PROVER_PRIVATE_KEY}
         --maxConcurrentProvingJobs ${ZKEVM_CHAIN_INSTANCES_NUM}"
 
-    taiko-client prover {$ARGS}
+    taiko-client prover ${ARGS}
 else
     sleep infinity
 fi


### PR DESCRIPTION
The curly brace is incorrect. As a result, the relayer does not work - simple-taiko-node-taiko_client_prover_relayer-1 exited with code 1.  This fix fixes the bug.