### PR TITLE
fix(eldfell): fix `--proveUnassignedBlocks` flag setting

### DIFF
--- a/script/l3/start-prover-relayer.sh
+++ b/script/l3/start-prover-relayer.sh
@@ -30,9 +30,8 @@ if [ "$ENABLE_PROVER" == "true" ]; then
     if [[ ! -z "$PROVE_UNASSIGNED_BLOCKS" ]]; then
         ARGS="${ARGS} --prover.proveUnassignedBlocks"
     else
-        ARGS="${ARGS} --prover.proveUnassignedBlocks false"
+        ARGS="${ARGS} --prover.proveUnassignedBlocks=false"
     fi
-    
 
     taiko-client prover ${ARGS}
 else


### PR DESCRIPTION
When using `--proveUnassignedBlocks false`, golang cli will parse the flag value as `true`, we need to use `--proveUnassignedBlocks=false`