### PR TITLE
feat(prover): proof skip size for l3

### DIFF
--- a/.env.sample.l3
+++ b/.env.sample.l3
@@ -40,7 +40,9 @@ ZKEVM_CHAIN_INSTANCES_NUM=1
 L2_PROVER_PRIVATE_KEY=
 # Gas limit for proveBlock transactions (in gas)
 PROVE_BLOCK_TX_GAS_LIMIT=1000000
-
+# Skip size, proof every N blocks, set to a number to prove every 10th, 12th, 15th, 18th block, etc.
+# instead of every block
+PROOF_SKIP_SIZE=
 # If you want to be a proposer who proposes L3 execution engine's transactions in mempool to Taiko L1 protocol (on L2)
 # contract (be a "mining L3 node"), you need to change `ENABLE_PROPOSER` to true, then fill `L2_PROPOSER_PRIVATE_KEY`
 # and `L3_SUGGESTED_FEE_RECIPIENT`

--- a/script/l3/start-prover-relayer.sh
+++ b/script/l3/start-prover-relayer.sh
@@ -31,6 +31,10 @@ if [ "$ENABLE_PROVER" == "true" ]; then
         ARGS="${ARGS} --prover.proveBlockTxGasLimit ${PROVE_BLOCK_TX_GAS_LIMIT}"
     fi
 
+    if [[ ! -z "$PROOF_SKIP_SIZE" ]]; then
+        ARGS="${ARGS} --prover.proofSkipSize ${PROOF_SKIP_SIZE}"
+    fi
+
     if [ "$PROVE_UNASSIGNED_BLOCKS" == "true" ]; then
         ARGS="${ARGS} --prover.proveUnassignedBlocks"
     fi


### PR DESCRIPTION
pr relies on https://github.com/taikoxyz/taiko-client/pull/362

this will let people skip every N blocks, which should help with our unverified blocks backlog, since many peopel are competing for the same block, even with 60,000 unverified blocks.

setting PROOF_SKIP_SIZE=randomNumber will let the user prove a block with less chance of collision.