### PR TITLE
fix(prover): prover needs taikotoken address, and re-add prove unassigned blocks

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -60,6 +60,9 @@ BLOCK_PROPOSAL_FEE=1
 # Comma-delineated list of prover endpoints proposer should query when attempting to propose a block
 # If you keep this default value you must also enable a prover by setting ENABLE_PROVER=true
 PROVER_ENDPOINTS=http://taiko_client_prover_relayer:9876
+# Whether to prove unassigned blocks or not (blocks that have expired their proof window
+# without the original prover submitting a proof.)
+PROVE_UNASSIGNED_BLOCKS=false
 
 # Comma-delimited local tx pool addresses you want to prioritize, useful to set your proposer to only propose blocks with your prover's transactions
 TXPOOL_LOCALS=

--- a/script/start-prover-relayer.sh
+++ b/script/start-prover-relayer.sh
@@ -16,6 +16,7 @@ if [ "$ENABLE_PROVER" == "true" ]; then
         --l2.http http://l2_execution_engine:8545
         --taikoL1 ${TAIKO_L1_ADDRESS}
         --taikoL2 ${TAIKO_L2_ADDRESS}
+        --taikoToken ${TAIKO_TOKEN_L1_ADDRESS}
         --zkevmRpcdEndpoint http://zkevm_chain_prover_rpcd:9000
         --zkevmRpcdParamsPath /data
         --l1.proverPrivKey ${L1_PROVER_PRIVATE_KEY}
@@ -25,6 +26,10 @@ if [ "$ENABLE_PROVER" == "true" ]; then
 
     if [[ ! -z "$PROVE_BLOCK_TX_GAS_LIMIT" ]]; then
         ARGS="${ARGS} --prover.proveBlockTxGasLimit ${PROVE_BLOCK_TX_GAS_LIMIT}"
+    fi
+
+    if [[ ! -z "$PROVE_UNASSIGNED_BLOCKS" ]]; then
+        ARGS="${ARGS} --prover.proveUnassignedBlocks"
     fi
 
     taiko-client prover ${ARGS}


### PR DESCRIPTION
relies on https://github.com/taikoxyz/taiko-client/pull/407 being cherry picked into jolnir.

community wanted to prove unassigned blocks again, so i re-added the flag.