### PR TITLE
feat(node): Echo Notification for Disabled Proposer Prior to Infinite Sleep

### DIFF
--- a/script/start-proposer.sh
+++ b/script/start-proposer.sh
@@ -29,5 +29,6 @@ fi
 if [ "$ENABLE_PROPOSER" == "true" ]; then
     taiko-client proposer ${ARGS}
 else
+    echo "PROPOSER IS DISABLED"
     sleep infinity
 fi


### PR DESCRIPTION
Encountered an issue where the script would hang indefinitely without any feedback due to the ENABLE_PROPOSER being set to false. This enhancement introduces an explicit echo notification to inform the user that the proposer is disabled before the script enters an infinite sleep. This provides clearer context during execution.