### PR TITLE
replace image link and fix some usages of scripts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ x-logging: &logging
 
 services:
   l2_execution_engine:
-    image: gcr.io/evmchain/taiko-geth:jolnir
+    image: gcr.dockerproxy.com/evmchain/taiko-geth:jolnir
     restart: unless-stopped
     pull_policy: always
     stop_grace_period: 3m
@@ -56,7 +56,7 @@ services:
     <<: *logging
 
   taiko_client_driver:
-    image: gcr.io/evmchain/taiko-client:jolnir
+    image: gcr.dockerproxy.com/evmchain/taiko-client:jolnir
     restart: unless-stopped
     pull_policy: always
     depends_on:
@@ -73,7 +73,7 @@ services:
     <<: *logging
 
   taiko_client_prover_relayer:
-    image: gcr.io/evmchain/taiko-client:jolnir
+    image: gcr.dockerproxy.com/evmchain/taiko-client:jolnir
     restart: unless-stopped
     pull_policy: always
     depends_on:
@@ -93,7 +93,7 @@ services:
     <<: *logging
 
   taiko_client_proposer:
-    image: gcr.io/evmchain/taiko-client:jolnir
+    image: gcr.dockerproxy.com/evmchain/taiko-client:jolnir
     restart: unless-stopped
     pull_policy: always
     depends_on:
@@ -110,7 +110,7 @@ services:
     <<: *logging
 
   zkevm_chain_prover_rpcd:
-    image: gcr.io/evmchain/jolnir-proverd:latest
+    image: gcr.dockerproxy.com/evmchain/jolnir-proverd:latest
     restart: unless-stopped
     pull_policy: always
     env_file:

--- a/script/start-driver.sh
+++ b/script/start-driver.sh
@@ -2,23 +2,23 @@
 
 set -eou pipefail
 
-if [ "$DISABLE_P2P_SYNC" == "false" ]; then
+if [ "$DISABLE_P2P_SYNC" = "false" ]; then
     taiko-client driver \
-        --l1.ws ${L1_ENDPOINT_WS} \
+        --l1.ws "${L1_ENDPOINT_WS}" \
         --l2.ws ws://l2_execution_engine:8546 \
         --l2.auth http://l2_execution_engine:8551 \
-        --taikoL1 ${TAIKO_L1_ADDRESS} \
-        --taikoL2 ${TAIKO_L2_ADDRESS} \
+        --taikoL1 "${TAIKO_L1_ADDRESS}" \
+        --taikoL2 "${TAIKO_L2_ADDRESS}" \
         --jwtSecret /data/taiko-geth/geth/jwtsecret \
         --p2p.syncVerifiedBlocks \
         --p2p.checkPointSyncUrl https://rpc.jolnir.taiko.xyz \
         --p2p.syncTimeout "6000"
 else
     taiko-client driver \
-        --l1.ws ${L1_ENDPOINT_WS} \
+        --l1.ws "${L1_ENDPOINT_WS}" \
         --l2.ws ws://l2_execution_engine:8546 \
         --l2.auth http://l2_execution_engine:8551 \
-        --taikoL1 ${TAIKO_L1_ADDRESS} \
-        --taikoL2 ${TAIKO_L2_ADDRESS} \
+        --taikoL1 "${TAIKO_L1_ADDRESS}" \
+        --taikoL2 "${TAIKO_L2_ADDRESS}" \
         --jwtSecret /data/taiko-geth/geth/jwtsecret
 fi

--- a/script/start-proposer.sh
+++ b/script/start-proposer.sh
@@ -1,4 +1,3 @@
-
 #!/bin/sh
 
 set -eou pipefail
@@ -13,16 +12,16 @@ ARGS="--l1.ws ${L1_ENDPOINT_WS}
     --blockProposalFee ${BLOCK_PROPOSAL_FEE}
     --l2.suggestedFeeRecipient ${L2_SUGGESTED_FEE_RECIPIENT}"
 
-if [[ ! -z "$TXPOOL_LOCALS" ]]; then
+if [ -n "$TXPOOL_LOCALS" ]; then
     ARGS="${ARGS} --txpool.localsOnly"
     ARGS="${ARGS} --txpool.locals ${TXPOOL_LOCALS}"
 fi
 
-if [[ ! -z "$PROPOSE_BLOCK_TX_GAS_LIMIT" ]]; then
+if [ -n "$PROPOSE_BLOCK_TX_GAS_LIMIT" ]; then
     ARGS="${ARGS} --proposeBlockTxGasLimit ${PROPOSE_BLOCK_TX_GAS_LIMIT}"
 fi
 
-if [[ ! -z "$PROPOSE_BLOCK_TX_GAS_TIP_CAP" ]]; then
+if [ -n "$PROPOSE_BLOCK_TX_GAS_TIP_CAP" ]; then
     ARGS="${ARGS} --proposeBlockTxGasTipCap ${PROPOSE_BLOCK_TX_GAS_TIP_CAP}"
 fi
 

--- a/script/start-prover-relayer.sh
+++ b/script/start-prover-relayer.sh
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-if [ "$ENABLE_PROVER" == "true" ]; then
+if [ "$ENABLE_PROVER" = "true" ]; then
     if [ ! -f "./wait" ];then
         wget https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait
         chmod +x ./wait
@@ -24,11 +24,11 @@ if [ "$ENABLE_PROVER" == "true" ]; then
         --prover.capacity ${ZKEVM_CHAIN_INSTANCES_NUM}
         --maxConcurrentProvingJobs ${ZKEVM_CHAIN_INSTANCES_NUM}"
 
-    if [[ ! -z "$PROVE_BLOCK_TX_GAS_LIMIT" ]]; then
+    if [ -n "$PROVE_BLOCK_TX_GAS_LIMIT" ]; then
         ARGS="${ARGS} --prover.proveBlockTxGasLimit ${PROVE_BLOCK_TX_GAS_LIMIT}"
     fi
 
-    if [[ "$PROVE_UNASSIGNED_BLOCKS" == "true" ]]; then
+    if [ "$PROVE_UNASSIGNED_BLOCKS" = "true" ]; then
         ARGS="${ARGS} --prover.proveUnassignedBlocks"
     fi
 

--- a/script/start-zkevm-chain-rpcd.sh
+++ b/script/start-zkevm-chain-rpcd.sh
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-if [ "$ENABLE_PROVER" == "true" ]; then
+if [ "$ENABLE_PROVER" = "true" ]; then
     mkdir -p /data
 
     if [ ! -f "/data/kzg_bn254_22.srs" ];then


### PR DESCRIPTION
docker-compose change:
1. replace the image link from `gcr.io/xxx` to `gcr.dockerproxy.com`, so that users can pull images without a Google Cloud account.

shell script changes:
1. In POSIX sh, [[ ]] is undefined.
2. In POSIX sh, == in place of = is undefined.
3. Use -n instead of ! -z.
4. Double quote to prevent globbing and word splitting.