### PR TITLE
fix: correct IP format in .env.sample endpoints

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -26,7 +26,7 @@ DISABLE_P2P_SYNC=false
 ############################### REQUIRED #####################################
 # L1 Holesky RPC endpoints (you will need an RPC provider such as Infura or Alchemy, or run a full Holesky node yourself)
 # If you are using a local Holesky L1 node, you can refer to it as "http://host.docker.internal:8545" and "ws://host.docker.internal:8546", which refer to the default ports in the .env for an eth-docker L1 node.
-# However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http:/192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
+# However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http://192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
 L1_ENDPOINT_HTTP=
 L1_ENDPOINT_WS=
 


### PR DESCRIPTION
Changed the IP address format in the .env.sample file from 'http:/192.168.1.15:8545' to 'http://192.168.1.15:8545'. This corrects an issue that could lead to connection problems for new users attempting to connect to the archive node using these endpoint examples