### PR TITLE
chore(protocol): add robust wget error handling in script

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -26,7 +26,7 @@ DISABLE_P2P_SYNC=false
 ############################### REQUIRED #####################################
 # L1 Holesky RPC endpoints (you will need an RPC provider such as Infura or Alchemy, or run a full Holesky node yourself)
 # If you are using a local Holesky L1 node, you can refer to it as "http://host.docker.internal:8545" and "ws://host.docker.internal:8546", which refer to the default ports in the .env for an eth-docker L1 node.
-# However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http:/192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
+# However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http://192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
 L1_ENDPOINT_HTTP=
 L1_ENDPOINT_WS=
 

--- a/script/start-prover-relayer.sh
+++ b/script/start-prover-relayer.sh
@@ -4,7 +4,10 @@ set -eou pipefail
 
 if [ "$ENABLE_PROVER" = "true" ]; then
     if [ ! -f "./wait" ];then
-        wget https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait
+       wget https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait -O ./wait || {
+            echo "Error: Failed to download wait utility."
+            exit 1
+        }
         chmod +x ./wait
     fi
 


### PR DESCRIPTION
## Overview
This PR introduces enhanced error handling for the `wget` command in our protocol script. It aims to improve the reliability and robustness of script operations, especially in scenarios where external dependencies are involved.

## Changes
- Implemented error checking for the `wget` command to handle download failures.
- Added an error message and an immediate exit from the script if `wget` fails, ensuring the script does not proceed with incomplete or incorrect setups.

## Rationale
Ensuring that our scripts fail gracefully and provide clear error messages is essential, particularly in automated and production environments. This update aligns with our ongoing efforts to improve the reliability and maintainability of our protocol scripts.

## Code Snippet
```sh
wget https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait -O ./wait || {
    echo "Error: Failed to download wait utility."
    exit 1
}
