### PR TITLE
chore(script): Upgrade docker-compose-wait and refactor shebang to Bash

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -26,7 +26,7 @@ DISABLE_P2P_SYNC=false
 ############################### REQUIRED #####################################
 # L1 Holesky RPC endpoints (you will need an RPC provider such as Infura or Alchemy, or run a full Holesky node yourself)
 # If you are using a local Holesky L1 node, you can refer to it as "http://host.docker.internal:8545" and "ws://host.docker.internal:8546", which refer to the default ports in the .env for an eth-docker L1 node.
-# However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http:/192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
+# However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http://192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
 L1_ENDPOINT_HTTP=
 L1_ENDPOINT_WS=
 

--- a/script/start-driver.sh
+++ b/script/start-driver.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eou pipefail
 

--- a/script/start-proposer.sh
+++ b/script/start-proposer.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eou pipefail
 

--- a/script/start-prover-relayer.sh
+++ b/script/start-prover-relayer.sh
@@ -4,7 +4,10 @@ set -eou pipefail
 
 if [ "$ENABLE_PROVER" = "true" ]; then
     if [ ! -f "./wait" ];then
-        wget https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait
+       wget https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait -O ./wait || {
+            echo "Error: Failed to download wait utility."
+            exit 1
+        }
         chmod +x ./wait
     fi
 

--- a/script/start-prover-relayer.sh
+++ b/script/start-prover-relayer.sh
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eou pipefail
 
 if [ "$ENABLE_PROVER" = "true" ]; then
     if [ ! -f "./wait" ];then
-       wget https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait -O ./wait || {
+       wget https://github.com/ufoscout/docker-compose-wait/releases/download/2.12.1/wait -O ./wait || {
             echo "Error: Failed to download wait utility."
             exit 1
         }


### PR DESCRIPTION
### Changes Overview
PR brings two key updates to the script handling the `taiko-client` prover process:

1. **Upgrade of docker-compose-wait**: The script now uses version 2.12.1 of docker-compose-wait, replacing the previous version 2.9.0. This upgrade incorporates the latest features and bug fixes from the docker-compose-wait utility.

2. **Switch to Bash Shebang**: The script's shebang line has been updated from `#!/bin/sh` to `#!/bin/bash`. This change enhances script compatibility across different systems and ensures better handling of bash-specific features.

**Rationale:**
- Ensures the latest utility features and fixes.
- Improves script compatibility and reliability.