### PR TITLE
feat(prover): add `PROVER IS DISABLED` log

### DIFF
--- a/script/start-prover-relayer.sh
+++ b/script/start-prover-relayer.sh
@@ -41,5 +41,6 @@ if [ "$ENABLE_PROVER" = "true" ]; then
 
     taiko-client prover ${ARGS}
 else
+    echo "PROVER IS DISABLED"
     sleep infinity
 fi

--- a/script/start-zkevm-chain-rpcd.sh
+++ b/script/start-zkevm-chain-rpcd.sh
@@ -13,5 +13,6 @@ if [ "$ENABLE_PROVER" = "true" ]; then
         --bind 0.0.0.0:9000 \
         --lookup zkevm_chain_prover_rpcd:9000
 else
+    echo "PROVER IS DISABLED"
     sleep infinity
 fi


### PR DESCRIPTION
This adds a `PROVER IS DISABLED` echo in `start-prover-relayer.sh` and `start-zkevm-chain-rpcd.sh`, when the prover is disabled. This is useful when reviewing the log, and spotting potential `.env` issues in enabling the prover. A similar message already exists for `start-proposer.sh`.

Example usage for spotting it in log:
```
root@host:~/simple-taiko-node# docker compose logs -f taiko_client_prover_relayer
simple-taiko-node-taiko_client_prover_relayer-1  | PROVER IS DISABLED
root@host:~/simple-taiko-node# docker compose logs -f zkevm_chain_prover_rpcd
simple-taiko-node-zkevm_chain_prover_rpcd-1  | PROVER IS DISABLED
```