### PR TITLE
fix: Update L1 Provider tip

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -24,7 +24,7 @@ TAIKO_L2_ADDRESS=0x1670080000000000000000000000000000010001
 DISABLE_P2P_SYNC=false
 
 ############################### REQUIRED #####################################
-# L1 Holesky RPC endpoints (you will need an RPC provider such as Infura or Alchemy, or run a full Holesky node yourself)
+# L1 Holesky RPC endpoints (you will need an RPC provider such as BlockPi, or run a full Holesky node yourself)
 # If you are using a local Holesky L1 node, you can refer to it as "http://host.docker.internal:8545" and "ws://host.docker.internal:8546", which refer to the default ports in the .env for an eth-docker L1 node.
 # However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http://192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
 L1_ENDPOINT_HTTP=


### PR DESCRIPTION
Previously, Infura or Alchemy were recomended for their free Sepolia endpoint but they don't offer a Holesky endpoint. BlockPi does, so I propose referring users to that service instead for Alpha 6