### PR TITLE
update script file

### DIFF
--- a/script/start-prover-relayer.sh
+++ b/script/start-prover-relayer.sh
@@ -44,3 +44,4 @@ else
     echo "PROVER IS DISABLED"
     sleep infinity
 fi
+

--- a/script/start-zkevm-chain-rpcd.sh
+++ b/script/start-zkevm-chain-rpcd.sh
@@ -13,6 +13,6 @@ if [ "$ENABLE_PROVER" = "true" ]; then
         --bind 0.0.0.0:9000 \
         --lookup zkevm_chain_prover_rpcd:9000
 else
-    echo "PROVER IS DISABLED"
     sleep infinity
 fi
+

--- a/script/start-zkevm-chain-rpcd.sh
+++ b/script/start-zkevm-chain-rpcd.sh
@@ -13,6 +13,7 @@ if [ "$ENABLE_PROVER" = "true" ]; then
         --bind 0.0.0.0:9000 \
         --lookup zkevm_chain_prover_rpcd:9000
 else
+    echo "PROVER IS DISABLED"
     sleep infinity
 fi
 


### PR DESCRIPTION
There are hidden characters in the original file, causing the `taiko-katla-taiko_client_prover_relayer and taiko-katla-zkevm_chain_prover_rpcd` container to fail to start when docker-compose is executed on the Linux server.

![image](https://github.com/taikoxyz/simple-taiko-node/assets/99468087/10cde141-1499-4159-9901-3ccae425e079)
