### PR TITLE
fix: remove obsolete docker-compose.yml version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 x-logging: &logging
   logging:
     options:


### PR DESCRIPTION
Removes the obsolete docker-compose.yml version warning

fixes https://github.com/taikoxyz/simple-taiko-node/issues/210
