### PR TITLE
feat: Updated .env.sample to clarify token amounts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -50,7 +50,7 @@ PROVER_CAPACITY=1
 L1_PROVER_PRIVATE_KEY=
 # Minimum accepted fee for accepting proving a block (in Gwei).
 MIN_ACCEPTABLE_PROOF_FEE=1
-# Amount to approve AssignmentHook + TaikoL1 contracts for TaikoToken usage.
+# Amount to approve AssignmentHook + TaikoL1 contracts for TaikoToken usage. i.e 250 TTKOh = 250
 TOKEN_ALLOWANCE=
 # Minimum ETH balance (in ETH) a prover wants to keep.
 MIN_ETH_BALANCE=


### PR DESCRIPTION
Issues Encountered:
I noticed an inconsistency in the description and the input format for TOKEN_ALLOWANCE= and MIN_TKO_BALANCE=. Specifically, the format for TOKEN_ALLOWANCE= led to a significant error where I unintentionally approved 251e+38, resulting in a loss of 2000 TTKOh within just 10 minutes.

These revisions aim to clarify that the values should be entered in the smallest unit and provide explicit examples directly in the comments. I believe these changes will make the configuration settings more intuitive and prevent costly errors.

Thank you for considering these modifications.
