### PR TITLE
docs: Update .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,7 +29,7 @@ DISABLE_P2P_SYNC=false
 # However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http://192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
 L1_ENDPOINT_HTTP=
 L1_ENDPOINT_WS=
-# HTTP RPC endpoint of a L1 beacon node.
+# HTTP RPC endpoint of a L1 beacon node. Everything behind the top-level domain is ignored. Make sure you don't need to work with subdirectories. The path will always be /eth/v1...
 L1_BEACON_HTTP=
 
 # REQUIRED FOR PROVER


### PR DESCRIPTION
Added description for L1_BEACON_HTTP, as often errors came up for users using a third party host where the API key is part of the URL.