### PR TITLE
feat: update checkout actions v3 to v4

### DIFF
--- a/.github/workflows/openai-review.yml
+++ b/.github/workflows/openai-review.yml
@@ -7,7 +7,7 @@ jobs:
     name: OpenAI PR Comment
     if: "contains(github.event.pull_request.labels.*.name, 'option.review-by-ai')"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2


### PR DESCRIPTION
## changes
actions/checkout version update v3 to v4

## reason for changes
If it is not a problem, it is a good to keep up with the version tracking.
The major change is that the default runtime will be node20, but since this is not expected to be a problem on this actions.

[actions v4 relaese details](https://github.com/actions/checkout/releases)