### PR TITLE
feat(hekla): introduce `--gpo.ignoreprice` flag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       --ws.api debug,eth,net,web3,txpool,taiko
       --ws.addr "0.0.0.0"
       --ws.origins "*"
+      --gpo.ignoreprice "100000000"
     <<: *logging
     profiles:
       - l2_execution_engine


### PR DESCRIPTION
To ignore the `0` gas price anchor transactions when doing the gas price suggestion.