### PR TITLE
fix(grafana): Set 'Instant' as default query type for instant metrics

### DIFF
--- a/docker/grafana/custom/l2/provisioning/dashboards/l2-execution-engine-overview-dashboard.json
+++ b/docker/grafana/custom/l2/provisioning/dashboards/l2-execution-engine-overview-dashboard.json
@@ -727,6 +727,7 @@
         {
           "expr": "chain_head_header{instance=~\"$instance\", job=~\"$job\"}",
           "format": "time_series",
+          "instant": true,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -1097,6 +1098,7 @@
         {
           "expr": "chain_head_receipt{instance=~\"$instance\", job=~\"$job\"}",
           "format": "time_series",
+          "instant": true,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",
@@ -1237,6 +1239,7 @@
         {
           "expr": "chain_head_block{instance=~\"$instance\", job=~\"$job\"}",
           "format": "time_series",
+          "instant": true,
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "",


### PR DESCRIPTION
This ensures that metrics like `latest header`, `latest receipt`, and `latest block` display the accurate last state values instead of averages from the time series.

fixes #246 