### PR TITLE
fix: update docker-compose.yml for better p2p configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       - "${PORT_L2_EXECUTION_ENGINE_METRICS}:6060"
       - "${PORT_L2_EXECUTION_ENGINE_HTTP}:8545"
       - "${PORT_L2_EXECUTION_ENGINE_WS}:8546"
-      - "${PORT_L2_EXECUTION_ENGINE_P2P}:30303"
-      - "${PORT_L2_EXECUTION_ENGINE_P2P}:30303/udp"
+      - "${PORT_L2_EXECUTION_ENGINE_P2P}:${PORT_L2_EXECUTION_ENGINE_P2P}"
+      - "${PORT_L2_EXECUTION_ENGINE_P2P}:${PORT_L2_EXECUTION_ENGINE_P2P}/udp"
     command: |
       --taiko
       --networkid "${CHAIN_ID}"
@@ -38,6 +38,11 @@ services:
       --ws.addr "0.0.0.0"
       --ws.origins "*"
       --gpo.ignoreprice "100000000"
+      --port ${PORT_L2_EXECUTION_ENGINE_P2P}
+      --discovery.port ${PORT_L2_EXECUTION_ENGINE_P2P}
+      --maxpeers ${MAXPEERS:-50}
+      --maxpendpeers ${MAXPENDPEERS:-0}
+      ${GETH_ADDITIONAL_ARGS}
     <<: *logging
     profiles:
       - l2_execution_engine


### PR DESCRIPTION
With the current configuration, geth broadcasts the wrong port and can only connect to bootnodes from the env file.