### PR TITLE
fix: add default value for GETH_ADDITIONAL_ARGS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       --discovery.port ${PORT_L2_EXECUTION_ENGINE_P2P}
       --maxpeers ${MAXPEERS:-50}
       --maxpendpeers ${MAXPENDPEERS:-0}
-      ${GETH_ADDITIONAL_ARGS}
+      ${GETH_ADDITIONAL_ARGS:-}
     <<: *logging
     profiles:
       - l2_execution_engine


### PR DESCRIPTION
Added a default value for GETH_ADDITIONAL_ARGS to remove the annoying warning `The "GETH_ADDITIONAL_ARGS" variable is not set.`