### PR TITLE
Update .env.sample file for Mainnet

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -27,8 +27,8 @@ DISABLE_P2P_SYNC=false
 P2P_SYNC_URL=https://rpc.mainnet.taiko.xyz
 
 ############################### REQUIRED #####################################
-# L1 Holesky RPC endpoints (you will need an RPC provider such as BlockPi, or run a full Holesky node yourself)
-# If you are using a local Holesky L1 node, you can refer to it as "http://host.docker.internal:8545" and "ws://host.docker.internal:8546", which refer to the default ports in the .env for an eth-docker L1 node.
+# L1 Mainnet RPC endpoints (you will need an RPC provider such as BlockPi, or run a full Holesky node yourself)
+# If you are using a local Mainnet L1 node, you can refer to it as "http://host.docker.internal:8545" and "ws://host.docker.internal:8546", which refer to the default ports in the .env for an eth-docker L1 node.
 # However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http://192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
 L1_ENDPOINT_HTTP=
 L1_ENDPOINT_WS=

--- a/.env.sample
+++ b/.env.sample
@@ -27,7 +27,7 @@ DISABLE_P2P_SYNC=false
 P2P_SYNC_URL=https://rpc.mainnet.taiko.xyz
 
 ############################### REQUIRED #####################################
-# L1 Mainnet RPC endpoints (you will need an RPC provider such as BlockPi, or run a full Holesky node yourself)
+# L1 Mainnet RPC endpoints (you will need an RPC provider such as BlockPi, or run a full Mainnet node yourself)
 # If you are using a local Mainnet L1 node, you can refer to it as "http://host.docker.internal:8545" and "ws://host.docker.internal:8546", which refer to the default ports in the .env for an eth-docker L1 node.
 # However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http://192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
 L1_ENDPOINT_HTTP=


### PR DESCRIPTION
Update the comments for L1 endpoints. Currently, it says L1 Holesky RPC three times, which should be changed to L1 Mainnet RPC. 