### PR TITLE
chore: remove beacon endpoint from env.samples

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -32,8 +32,6 @@ P2P_SYNC_URL=https://rpc.mainnet.taiko.xyz
 # However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http://192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
 L1_ENDPOINT_HTTP=
 L1_ENDPOINT_WS=
-# HTTP RPC endpoint of a L1 beacon node. Everything behind the top-level domain is ignored. Make sure you don't need to work with subdirectories. The path will always be /eth/v1...
-L1_BEACON_HTTP=
 
 ############################### OPTIONAL #####################################
 # If you want to be a prover who generates and submits zero knowledge proofs of proposed L2 blocks, you need to change

--- a/.env.sample.hekla
+++ b/.env.sample.hekla
@@ -32,8 +32,6 @@ P2P_SYNC_URL=https://rpc.hekla.taiko.xyz
 # However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http://192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
 L1_ENDPOINT_HTTP=
 L1_ENDPOINT_WS=
-# HTTP RPC endpoint of a L1 beacon node. Everything behind the top-level domain is ignored. Make sure you don't need to work with subdirectories. The path will always be /eth/v1...
-L1_BEACON_HTTP=
 
 ############################### OPTIONAL #####################################
 # If you want to be a prover who generates and submits zero knowledge proofs of proposed L2 blocks, you need to change


### PR DESCRIPTION
Assuming beacon endpoint is removed based on #290 