### PR TITLE
chore(main): Updating both .env.sample explaining how to use REST port.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -27,12 +27,14 @@ DISABLE_P2P_SYNC=false
 P2P_SYNC_URL=https://rpc.mainnet.taiko.xyz
 
 ############################### REQUIRED #####################################
-# L1 Mainnet RPC endpoints (you will need an RPC provider such as BlockPi, or run a full Mainnet node yourself)
+# L1 Mainnet RPC endpoints (you will need an RPC provider such as BlockPi, or run a full Mainnet node yourself).
 # If you are using a local Mainnet L1 node, you can refer to it as "http://host.docker.internal:8545" and "ws://host.docker.internal:8546", which refer to the default ports in the .env for an eth-docker L1 node.
 # However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http://192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
 L1_ENDPOINT_HTTP=
 L1_ENDPOINT_WS=
 # HTTP RPC endpoint of a L1 beacon node. Everything behind the top-level domain is ignored. Make sure you don't need to work with subdirectories. The path will always be /eth/v1...
+# If you are using a local Mainnet L1 node, you can refer to it as "http://host.docker.internal:5052", which refer to the default REST port in the .env for an eth-docker L1 node.
+# Or follow the recommendations for http RPC endoint using the default REST port "5250", (e.g. http://82.168.1.15:5052).
 L1_BEACON_HTTP=
 
 ############################### OPTIONAL #####################################

--- a/.env.sample
+++ b/.env.sample
@@ -35,7 +35,7 @@ L1_ENDPOINT_HTTP=
 L1_ENDPOINT_WS=
 # HTTP RPC endpoint of a L1 beacon node. Everything behind the top-level domain is ignored. Make sure you don't need to work with subdirectories. The path will always be /eth/v1...
 # If you are using a local Mainnet L1 node, you can refer to it as "http://host.docker.internal:5052", which refer to the default REST port in the .env for an eth-docker L1 node.
-# Or follow the recommendations for http RPC endoint using the default REST port "5250", (e.g. http://82.168.1.15:5052).
+# Or follow the recommendations for http RPC endoint using the default REST port "5052", (e.g. http://82.168.1.15:5052).
 L1_BEACON_HTTP=
 
 ############################### OPTIONAL #####################################

--- a/.env.sample
+++ b/.env.sample
@@ -30,6 +30,7 @@ P2P_SYNC_URL=https://rpc.mainnet.taiko.xyz
 # L1 Mainnet RPC endpoints (you will need an RPC provider such as BlockPi, or run a full Mainnet node yourself).
 # If you are using a local Mainnet L1 node, you can refer to it as "http://host.docker.internal:8545" and "ws://host.docker.internal:8546", which refer to the default ports in the .env for an eth-docker L1 node.
 # However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http://192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
+# In addition, you can use your public ip address followed by the specific ports for http and ws (e.g. http://82.168.1.15:8545). You can find that with `hostname -I | awk '{print $1}'`.
 L1_ENDPOINT_HTTP=
 L1_ENDPOINT_WS=
 # HTTP RPC endpoint of a L1 beacon node. Everything behind the top-level domain is ignored. Make sure you don't need to work with subdirectories. The path will always be /eth/v1...

--- a/.env.sample.hekla
+++ b/.env.sample.hekla
@@ -26,12 +26,15 @@ DISABLE_P2P_SYNC=false
 P2P_SYNC_URL=https://rpc.hekla.taiko.xyz
 
 ############################### REQUIRED #####################################
-# L1 Holesky RPC endpoints (you will need an RPC provider such as BlockPi, or run a full Holesky node yourself)
+# L1 Holesky RPC endpoints (you will need an RPC provider such as BlockPi, or run a full Holesky node yourself).
 # If you are using a local Holesky L1 node, you can refer to it as "http://host.docker.internal:8545" and "ws://host.docker.internal:8546", which refer to the default ports in the .env for an eth-docker L1 node.
 # However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http://192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
+# In addition, you can use your public ip address followed by the specific ports for http and ws (e.g. http://82.168.1.15:8545). You can find that with `hostname -I | awk '{print $1}'`.
 L1_ENDPOINT_HTTP=
 L1_ENDPOINT_WS=
 # HTTP RPC endpoint of a L1 beacon node. Everything behind the top-level domain is ignored. Make sure you don't need to work with subdirectories. The path will always be /eth/v1...
+# If you are using a local Holesky L1 node, you can refer to it as "http://host.docker.internal:5052", which refer to the default REST port in the .env for an eth-docker L1 node.
+# Or follow the recommendations for http RPC endoint using the default REST port "5250", (e.g. http://82.168.1.15:5052).
 L1_BEACON_HTTP=
 
 ############################### OPTIONAL #####################################

--- a/.env.sample.hekla
+++ b/.env.sample.hekla
@@ -34,7 +34,7 @@ L1_ENDPOINT_HTTP=
 L1_ENDPOINT_WS=
 # HTTP RPC endpoint of a L1 beacon node. Everything behind the top-level domain is ignored. Make sure you don't need to work with subdirectories. The path will always be /eth/v1...
 # If you are using a local Holesky L1 node, you can refer to it as "http://host.docker.internal:5052", which refer to the default REST port in the .env for an eth-docker L1 node.
-# Or follow the recommendations for http RPC endoint using the default REST port "5250", (e.g. http://82.168.1.15:5052).
+# Or follow the recommendations for http RPC endoint using the default REST port "5052", (e.g. http://82.168.1.15:5052).
 L1_BEACON_HTTP=
 
 ############################### OPTIONAL #####################################


### PR DESCRIPTION
I have added in the .env.sample files the descriptions in both mainnet and testnet, so they can use theirs L1 node as beacon RPC.