### PR TITLE
chore(env): update `.env.sample.hekla`

### DIFF
--- a/.env.sample.hekla
+++ b/.env.sample.hekla
@@ -30,6 +30,7 @@ P2P_SYNC_URL=https://rpc.hekla.taiko.xyz
 # If you are using a local Holesky L1 node, you can refer to it as "http://host.docker.internal:8545" and "ws://host.docker.internal:8546", which refer to the default ports in the .env for an eth-docker L1 node.
 # However, you may need to add this host to docker-compose.yml. If that does not work, you can try the private local ip address (e.g. http://192.168.1.15:8545). You can find that with `ip addr show` or a similar command.
 # In addition, you can use your public ip address followed by the specific ports for http and ws (e.g. http://82.168.1.15:8545). You can find that with `hostname -I | awk '{print $1}'`.
+L1_ENDPOINT_HTTP=
 L1_ENDPOINT_WS=
 # HTTP RPC endpoint of a L1 beacon node. Everything behind the top-level domain is ignored. Make sure you don't need to work with subdirectories. The path will always be /eth/v1...
 # If you are using a local Holesky L1 node, you can refer to it as "http://host.docker.internal:5052", which refer to the default REST port in the .env for an eth-docker L1 node.


### PR DESCRIPTION
Missing `L1_ENDPOINT_HTTP=`